### PR TITLE
Add license file to the built module

### DIFF
--- a/BuildTasks/Copy.Task.ps1
+++ b/BuildTasks/Copy.Task.ps1
@@ -20,4 +20,10 @@ task Copy {
         'Creating [.{0}]...' -f $directory.FullName.Replace($buildroot, '')
         Copy-Item -Path $directory.FullName -Destination $Destination -Recurse -Force
     }
+
+    $license = Join-Path -Path $buildroot -ChildPath 'LICENSE'
+    if ( Test-Path -Path $license -PathType Leaf )
+    {
+        Copy-Item -Path $license -Destination $Destination
+    }
 }


### PR DESCRIPTION
When the module is built, this will make sure the license file is copied into the module. This way the license is included with published modules.
resolves #14