### PR TITLE
Move rule details into because statement

### DIFF
--- a/Tests/Project/Module.Tests.ps1
+++ b/Tests/Project/Module.Tests.ps1
@@ -16,16 +16,15 @@ Describe "All commands pass PSScriptAnalyzer rules" -Tag 'Build' {
             {
                 foreach ($rule in $results)
                 {
-                    It $rule.RuleName {
-                        $message = "{0} Line {1}: {2}" -f $rule.Severity, $rule.Line, $rule.Message
-                        $message | Should Be ""
+                    It ("{0}:{1} on line {2}" -f $rule.Severity,$rule.RuleName,$rule.Line) {
+                        $rule.Message | Should -Be "" -Because $rule.Message
                     }
                 }
             }
             else
             {
                 It "Should not fail any rules" {
-                    $results | Should BeNullOrEmpty
+                    $results | Should -BeNullOrEmpty
                 }
             }
         }
@@ -39,7 +38,7 @@ Describe "Public commands have Pester tests" -Tag 'Build' {
     {
         $file = Get-ChildItem -Path "$ModuleRoot\Tests" -Include "$command.Tests.ps1" -Recurse
         It "Should have a Pester test for [$command]" {
-            $file.FullName | Should Not BeNullOrEmpty
+            $file.FullName | Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
I cleaned up the way the failed tests look for script analyzer rules


before:

```
Context C:\source\KMT.ModuleBuilder\KMT.ModuleBuilder\public\Set-KmtOutputPsm1.ps1
      [-] PSUseShouldProcessForStateChangingFunctions 47ms
        Expected strings to be the same, but they were different.
        Expected length: 0
        Actual length:   141
        Strings differ at index 0.
        Expected: ''
        But was:  'Warning Li...'
        21:                         $message | Should Be ""
        at <ScriptBlock>, C:\source\KMT.ModuleBuilder\Tests\Project\Module.Tests.ps1: line 21
```

after change:

```
Context C:\source\KMT.ModuleBuilder\KMT.ModuleBuilder\public\Set-KmtOutputPsm1.ps1
      [-] Warning:PSUseShouldProcessForStateChangingFunctions on line 1 8ms
        Expected strings to be the same, because Function 'Set-KmtOutputPsm1' has verb that could change system state. Therefore, the function has to support 'ShouldProcess'., but they were different.
        Expected length: 0
        Actual length:   125
        Strings differ at index 0.
        Expected: ''
        But was:  'Function '...'
        20:                         $rule.Message | Should -Be "" -Because $rule.Message
        at <ScriptBlock>, C:\source\KMT.ModuleBuilder\Tests\Project\Module.Tests.ps1: line 20

```